### PR TITLE
Added message for test coverage

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ const (
 	EnvSiteName       = "SITE_NAME"
 	EnvHostName       = "HOST_NAME"
 	EnvDepolyPath     = "DEPLOY_PATH"
+	EnvCoverageURL    = "COVERAGE_URL"
 )
 
 type Webhook struct {
@@ -83,6 +84,18 @@ func main() {
 			Value: envOr(EnvSlackMessage, "EOM"),
 			Short: false,
 		},
+	}
+	coverageUrl := envOr(EnvCoverageURL, "")	
+	if coverageUrl != "" {
+		newfields:= []Field{
+			{
+				Title: "Test coverage URL",
+				Value: os.Getenv(coverageUrl),
+				Short: false,
+			},
+		}
+		fields = append(newfields, fields...)
+			
 	}
 
 	hostName := os.Getenv(EnvHostName)

--- a/main.go
+++ b/main.go
@@ -85,12 +85,12 @@ func main() {
 			Short: false,
 		},
 	}
-	coverageUrl := envOr(EnvCoverageURL, "")	
+	coverageUrl := os.Getenv(EnvCoverageURL) 
 	if coverageUrl != "" {
 		newfields:= []Field{
 			{
 				Title: "Test coverage URL",
-				Value: os.Getenv(coverageUrl),
+				Value: os.Getenv(EnvCoverageURL),
 				Short: false,
 			},
 		}

--- a/main.sh
+++ b/main.sh
@@ -5,7 +5,6 @@ export SLACK_USERNAME=${SLACK_USERNAME:-"GH Action - Build"}
 export CI_SCRIPT_OPTIONS="ci_script_options"
 export SLACK_TITLE=${SLACK_TITLE:-"Message"}
 export COMMIT_MESSAGE=$(cat "/github/workflow/event.json" | jq .commits | jq '.[0].message' -r)
-export COVERAGE_URL="-"
 
 # slack messages
 
@@ -29,10 +28,6 @@ else
 	export SLACK_COLOR=${!MSG_COLOR}
 fi
 
-if [[ -z "$COVERAGE_URL" ]]; then
-    export COVERAGE_URL
-    export COVERAGE_TITLE="Test coverage URL"
-fi
 
 hosts_file="$GITHUB_WORKSPACE/.github/hosts.yml"
 

--- a/main.sh
+++ b/main.sh
@@ -5,6 +5,7 @@ export SLACK_USERNAME=${SLACK_USERNAME:-"GH Action - Build"}
 export CI_SCRIPT_OPTIONS="ci_script_options"
 export SLACK_TITLE=${SLACK_TITLE:-"Message"}
 export COMMIT_MESSAGE=$(cat "/github/workflow/event.json" | jq .commits | jq '.[0].message' -r)
+export COVERAGE_URL="-"
 
 # slack messages
 
@@ -28,6 +29,10 @@ else
 	export SLACK_COLOR=${!MSG_COLOR}
 fi
 
+if [[ -z "$COVERAGE_URL" ]]; then
+    export COVERAGE_URL
+    export COVERAGE_TITLE="Test coverage URL"
+fi
 
 hosts_file="$GITHUB_WORKSPACE/.github/hosts.yml"
 


### PR DESCRIPTION
Uses env variable `COVERAGE_URL` to add coverage url to slack message. 